### PR TITLE
fix: coalescing-operator

### DIFF
--- a/src/components/CodeMirror.ts
+++ b/src/components/CodeMirror.ts
@@ -558,14 +558,15 @@ export default defineComponent({
     /** Retrieve one end of the primary selection. */
     const getCursor = (): number => view.value.state.selection.main.head;
     /** Retrieves a list of all current selections. */
-    const listSelections = (): readonly SelectionRange[] =>
-      view.value.state.selection.ranges ?? [];
+    const listSelections = (): readonly SelectionRange[]  => {
+      var _view$value$state$sel;
+      return (_view$value$state$sel = view.value.state.selection.ranges) !== null && _view$value$state$sel !== void 0 ? _view$value$state$sel : [];
+    };
     /** Get the currently selected code. */
-    const getSelection = (): string =>
-      view.value.state.sliceDoc(
-        view.value.state.selection.main.from,
-        view.value.state.selection.main.to
-      ) ?? '';
+    const getSelection = (): string => {
+      var _view$value$state$sli;
+      return (_view$value$state$sli = view.value.state.sliceDoc(view.value.state.selection.main.from, view.value.state.selection.main.to)) !== null && _view$value$state$sli !== void 0 ? _view$value$state$sli : '';
+    };
     /**
      * The length of the given array should be the same as the number of active selections.
      * Replaces the content of the selections with the strings in the array.


### PR DESCRIPTION
when i make a formula-editor lib use vue-codemirror6 as dependence.
and i have a project using formula-editor lib, 
i got a error:
`You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
|     const getCursor = () => view.value.state.selection.main.head;
|     const listSelections = () =>
>       view.value.state.selection.ranges ?? [];
|     const getSelection2 = () => view.value.state.sliceDoc(
|       view.value.state.selection.main.from,`
