### PR TITLE
fix: editor not update content when `modelValue` change and selection is out of range

### DIFF
--- a/src/components/CodeMirror.ts
+++ b/src/components/CodeMirror.ts
@@ -462,14 +462,14 @@ export default defineComponent({
 
         // Range Fix ?
         // https://github.com/logue/vue-codemirror6/issues/27
-        const isOutOfRange =  !view.value.state.selection.ranges.every(
+        const isSelectionOutOfRange =  !view.value.state.selection.ranges.every(
           range => range.anchor < value.length && range.head < value.length
         )
     
         // Update
         view.value.dispatch({
           changes: { from: 0, to: view.value.state.doc.length, insert: value },
-          selection: isOutOfRange ? { anchor: 0, head: 0 } : view.value.state.selection,
+          selection: isSelectionOutOfRange ? { anchor: 0, head: 0 } : view.value.state.selection,
           scrollIntoView: true,
         });
       },

--- a/src/components/CodeMirror.ts
+++ b/src/components/CodeMirror.ts
@@ -462,18 +462,14 @@ export default defineComponent({
 
         // Range Fix ?
         // https://github.com/logue/vue-codemirror6/issues/27
-        if (
-          !selection.value.ranges.every(
-            range => range.anchor < value.length && range.head < value.length
-          )
-        ) {
-          return;
-        }
-
+        const isOutOfRange =  !view.value.state.selection.ranges.every(
+          range => range.anchor < value.length && range.head < value.length
+        )
+    
         // Update
         view.value.dispatch({
           changes: { from: 0, to: view.value.state.doc.length, insert: value },
-          selection: view.value.state.selection,
+          selection: isOutOfRange ? { anchor: 0, head: 0 } : view.value.state.selection,
           scrollIntoView: true,
         });
       },


### PR DESCRIPTION
When change the modalValue of CodeEditor, if the current selection is out of range, the code editor content will not change.I think reset the selection range is better.

If you select the end line, then click the "change" button, code editor content will not change.
![image](https://github.com/logue/vue-codemirror6/assets/32869419/a358267f-f6ee-433a-b7a4-79a70426ab48)
CodeSandbox: https://codesandbox.io/p/devbox/laughing-bas-pn64jc?file=%2Fsrc%2Fcomponents%2FHelloWorld.vue%3A8%2C5